### PR TITLE
make full PGP fingerprint clickable

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -182,7 +182,7 @@
                         <div class="version-content">
                             <div class="text-center lh mb-5">
                                 <a href="https://github.com/zkSNACKs/WalletWasabi#build-from-source-code" target="_blank"><i class="muted-text">or build it from source</i></a>
-                                <br /> <a href="https://github.com/zkSNACKs/WalletWasabi/blob/master/PGP.txt" target="_blank">PGP</a> <span class="cursor-select">(6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E)</span>
+                                <br /> <a href="https://raw.githubusercontent.com/zkSNACKs/WalletWasabi/master/PGP.txt" target="_blank">PGP: 6FB3 872B 5D42 292F 5992 0797 8563 4832 8949 861E</a>
                                 <br /> <a href="https://github.com/zkSNACKs/WalletWasabi/releases" target="_blank" class="green-text">RELEASE NOTES</a>
                             </div>
                             <div class="row align-items-end">


### PR DESCRIPTION
https://github.com/zkSNACKs/WasabiWalletWebSite/issues/13#issuecomment-1792753458

- make full pgp fingerprint clickable
- modify the link to raw.githubusercontent
- also took this as the opportunity to change it from `PGP (X)` to `PGP: X`, as it makes more sense

[Screencast ](https://github.com/zkSNACKs/WasabiWalletWebSite/assets/93143998/8c555a5f-52b7-43aa-b5f7-415c7a7c8273)
